### PR TITLE
Turn DomainStatus into interface

### DIFF
--- a/src/DomainStatus.php
+++ b/src/DomainStatus.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace PayloadInterop;
 
-class DomainStatus
+interface DomainStatus
 {
     /**
      * Input accepted for later processing.
@@ -59,9 +59,4 @@ class DomainStatus
      * Update succeeded.
      */
     const UPDATED = 'UPDATED';
-
-    /**
-     * Disallow instantiation.
-     */
-    final private function __construct() {}
 }


### PR DESCRIPTION
As argued in #9, it makes more sense to have the `DomainStatus` be an interface, instead of a non-instantiable class.

This PR:
- changes the `DomainStatus` from a `class` to an `interface`
- removes the `final private` constructor

Fixes #9